### PR TITLE
Refactor/remove what comments

### DIFF
--- a/cmd/WarhammerCalcServer/main.go
+++ b/cmd/WarhammerCalcServer/main.go
@@ -33,7 +33,7 @@ import (
 //	@BasePath		/api
 
 func main() {
-	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile) // Optional: Better logging format
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 
 	if err := app.Run(); err != nil {
 		// Only handles the fatal error case, keeping main simple.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -142,7 +142,6 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "hit_modifier": {
-                    "description": "Modifiers (e.g., -1 to hit is -1)",
                     "type": "integer"
                 },
                 "lethal_hits": {
@@ -192,12 +191,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "summary": {
-                    "description": "Grouped or flattened as you prefer, but separate from the core",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/damagerequest.SummaryDTO"
-                        }
-                    ]
+                    "$ref": "#/definitions/damagerequest.SummaryDTO"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -136,7 +136,6 @@
                     "type": "boolean"
                 },
                 "hit_modifier": {
-                    "description": "Modifiers (e.g., -1 to hit is -1)",
                     "type": "integer"
                 },
                 "lethal_hits": {
@@ -186,12 +185,7 @@
                     "type": "string"
                 },
                 "summary": {
-                    "description": "Grouped or flattened as you prefer, but separate from the core",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/damagerequest.SummaryDTO"
-                        }
-                    ]
+                    "$ref": "#/definitions/damagerequest.SummaryDTO"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -26,7 +26,6 @@ definitions:
       devastating_wounds:
         type: boolean
       hit_modifier:
-        description: Modifiers (e.g., -1 to hit is -1)
         type: integer
       lethal_hits:
         type: boolean
@@ -59,9 +58,7 @@ definitions:
       request_uuid:
         type: string
       summary:
-        allOf:
-        - $ref: '#/definitions/damagerequest.SummaryDTO'
-        description: Grouped or flattened as you prefer, but separate from the core
+        $ref: '#/definitions/damagerequest.SummaryDTO'
     type: object
   damagerequest.DistributionsDTO:
     properties:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -93,7 +93,8 @@ func Apply(h http.Handler, middlewares ...Middleware) http.Handler {
 	return h
 }
 
-// BuildPublicHandler собирает и оборачивает публичную ветку
+// BuildPublicHandler assembles the unauthenticated route branch (health
+// checks and Swagger docs), wrapped in the given middleware chain.
 func BuildPublicHandler(middlewares ...Middleware) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/alive", HealthCheck)
@@ -205,27 +206,24 @@ func run(ctx context.Context) error {
 
 	calcCore := &calculator.DamageCalculatorImpl{}
 
-	// 1. Initialize Public-facing middleware (Auth-free zones like Healthchecks or Docs)
+	// Auth-free: health checks and Swagger docs.
 	publicMW := []Middleware{
 		// middleware.RateLimitMiddleware,
 	}
 
-	// 2. Initialize Protected middleware (Business logic, logging, and panic recovery)
 	protectedMW := []Middleware{
 		middleware.RecoverMiddleware(logger),
 		middleware.LoggingMiddleware(logger),
 	}
 
-	// 3. Initialize Global middleware (Applied to every single incoming request)
+	// Applies to every incoming request, including public ones.
 	globalMW := []Middleware{
 		middleware.CORSMiddleware(cfg.Origins),
 	}
 
-	// 4. Build isolated route branches
 	publicHandler := BuildPublicHandler(publicMW...)
 	protectedHandler := BuildProtectedHandler(calcCore, logger, protectedMW...)
 
-	// 5. Assemble the root router with global middleware wrapper
 	handler := BuildRootHandler(publicHandler, protectedHandler, globalMW...)
 
 	logger.Info("server starting",

--- a/internal/calculator/attack_dist.go
+++ b/internal/calculator/attack_dist.go
@@ -27,15 +27,14 @@ func CalculateAttackDistribution(
 	targetCount int,
 ) map[int]float64 {
 
-	// 1. Parse attack string into a PER-MODEL distribution
+	// PER-MODEL distribution.
 	perModelDist := getDiceDistribution(attacks)
 
-	// 2. Apply Blast (still PER-MODEL)
+	// Blast is applied per model, before scaling to the whole unit.
 	if blast {
 		perModelDist = applyBlastModifier(perModelDist, targetCount)
 	}
 
-	// 3. Scale per-model distribution by attacker count
 	unitDist := scaleByAttackerCount(perModelDist, attackerCount)
 
 	return unitDist
@@ -50,9 +49,8 @@ func applyDamageFloor(value int) int {
 
 func getDiceDistribution(attacks DiceRoll) map[int]float64 {
 
-	// Roll dice
 	dist := rollDiceDistribution(attacks.Count, attacks.Sides)
-	// Apply flat modifier AND damage floor (Damage cannot be < 1)
+	// Damage/attacks cannot be modified below 1.
 	finalDist := make(map[int]float64)
 	for val, p := range dist {
 		floored := applyDamageFloor(val + attacks.Modifier)
@@ -104,7 +102,6 @@ func scaleByAttackerCount(
 	count int,
 ) map[int]float64 {
 
-	// Start with zero total attacks
 	unitDist := map[int]float64{0: 1.0}
 
 	// Convolve the per-model distribution `count` times

--- a/internal/calculator/core.go
+++ b/internal/calculator/core.go
@@ -297,8 +297,10 @@ func (d *DamageCalculatorImpl) CalculateDamageCore(req CombatSimulationRequest) 
 	}
 
 	// ── 11. Damage allocation ──────────────────────────────────────
-	dmgWithFnp := _calculateDamageDistribution(req.Attacker.Damage, req.Target.FeelNoPain) // FNP applied here
-	dmgNoFnp := _calculateDamageDistribution(req.Attacker.Damage, req.Target.FeelNoPain)   // FNP for devastating - latest rules
+	// TODO: Some units grant Feel No Pain that explicitly excludes devastating
+	// wound damage. Not modeled — FNP is currently applied uniformly to both
+	// normal and devastating damage via dmgDist.
+	dmgDist := _calculateDamageDistribution(req.Attacker.Damage, req.Target.FeelNoPain)
 	finalKilledSlice := make([]float64, *req.Target.Count+1)
 
 	// NEW: Total Damage Accumulators
@@ -325,7 +327,7 @@ func (d *DamageCalculatorImpl) CalculateDamageCore(req CombatSimulationRequest) 
 				}
 				resolveDamageToSlice(
 					u, dw,
-					dmgWithFnp, dmgNoFnp,
+					dmgDist, dmgDist,
 					req.Target.WoundsPerModel,
 					*req.Target.Count,
 					finalKilledSlice,
@@ -338,7 +340,7 @@ func (d *DamageCalculatorImpl) CalculateDamageCore(req CombatSimulationRequest) 
 					prev := damageConvs[totalUnsaved-1]
 					curr := make([]float64, len(prev)+maxD)
 					for i, pPrev := range prev {
-						for dVal, pD := range dmgNoFnp {
+						for dVal, pD := range dmgDist {
 							curr[i+dVal] += pPrev * pD
 						}
 					}

--- a/internal/calculator/core.go
+++ b/internal/calculator/core.go
@@ -731,18 +731,7 @@ func (d *DamageCalculatorImpl) Hydrate(req *CombatSimulationRequest) {
 	if req.Target.Count == nil {
 		// Calculate the ceiling for target resolution
 		maxAttacks := GetMaxFromDice(req.Attacker.Attacks) * req.Attacker.Count
-		maxDamage := GetMaxFromDice(req.Attacker.Damage)
-
-		// Hardcoded false in original; assuming intended as a logic toggle
-		devastatingDoSpillover := false
-
-		var count int
-		if req.Attacker.DevastatingWounds && devastatingDoSpillover {
-			totalPossibleDamage := maxAttacks * maxDamage
-			count = (totalPossibleDamage / req.Target.WoundsPerModel) + 1
-		} else {
-			count = maxAttacks
-		}
+		count := maxAttacks
 
 		// Enforce DOS cap
 		if count > 200 {

--- a/internal/calculator/core.go
+++ b/internal/calculator/core.go
@@ -132,8 +132,6 @@ func (d *DamageCalculatorImpl) CalculateDamageCore(req CombatSimulationRequest) 
 	}
 
 	// ── 7. Hits distribution (exact, discrete) ─────────────────────
-	// globalHitDist[NormalHits][LethalHits]
-
 	// Determine per-attack bounds
 	maxNormalHitsPerAttack := maxNper
 	maxLethalHitsPerAttack := maxLper

--- a/internal/calculator/core_test.go
+++ b/internal/calculator/core_test.go
@@ -547,6 +547,26 @@ func TestDamageCalculatorImpl_Hydrate(t *testing.T) {
 			},
 		},
 		{
+			name: "Infinite Target Resolution Ignores DevastatingWounds",
+			input: CombatSimulationRequest{
+				Attacker: AttackerProfile{
+					Count:             1,
+					Attacks:           DiceRoll{Count: 10, Sides: 1, Modifier: 0},
+					Damage:            DiceRoll{Count: 2, Sides: 1, Modifier: 0},
+					DevastatingWounds: true,
+				},
+				Target: TargetProfile{Count: nil, WoundsPerModel: 2},
+			},
+			check: func(t *testing.T, got CombatSimulationRequest) {
+				if got.Target.Count == nil {
+					t.Fatal("Target.Count remains nil after Hydration")
+				}
+				if *got.Target.Count != 10 {
+					t.Errorf("count should resolve to maxAttacks (10) regardless of DevastatingWounds, got %d", *got.Target.Count)
+				}
+			},
+		},
+		{
 			name: "Enforces Hard Cap on Infinite Resolution",
 			input: CombatSimulationRequest{
 				// Massive damage potential requesting infinite targets

--- a/internal/calculator/core_test.go
+++ b/internal/calculator/core_test.go
@@ -443,6 +443,53 @@ func TestCalculateDamageCore_Torrent(t *testing.T) {
 	}
 }
 
+func TestCalculateDamageCore_FeelNoPain_AppliedToDevastatingWounds(t *testing.T) {
+	// Regression test locking in that Feel No Pain reduces devastating-wound
+	// damage exactly like normal damage — the two previously duplicated
+	// (dmgWithFnp/dmgNoFnp) calls made this easy to silently diverge. Torrent
+	// forces exactly 1 hit so only the Wound/Devastating/FNP math is under test.
+	req := CombatSimulationRequest{
+		Attacker: AttackerProfile{
+			Count:             1,
+			Attacks:           DiceRoll{Modifier: 1},
+			Torrent:           true,
+			Strength:          8,
+			DevastatingWounds: true,
+			Damage:            DiceRoll{Modifier: 4},
+		},
+		Target: TargetProfile{
+			Count:          intPtr(1),
+			Toughness:      4,
+			Save:           7,
+			WoundsPerModel: 10,
+			FeelNoPain:     intPtr(5),
+		},
+	}
+
+	// S8 vs T4 wounds on 2+ (5/6); default crit-wound threshold 6+ makes 1/6
+	// of those devastating (bypasses the impossible Save 7+) and 4/6 normal
+	// (also unsaved). FNP 5+ gives pFail = 2/3 per damage point. Both paths
+	// resolve through the identical 4-damage Binomial(4, 2/3) distribution,
+	// weighted by their combined 5/6 chance of occurring. WoundsPerModel=10
+	// keeps the single wound-instance well under model HP so damage is never
+	// capped by death, isolating the FNP math.
+	expectedDamageDist := map[int]float64{
+		0: 43.0 / 243.0,
+		1: 20.0 / 243.0,
+		2: 60.0 / 243.0,
+		3: 80.0 / 243.0,
+		4: 40.0 / 243.0,
+	}
+
+	calc := &DamageCalculatorImpl{}
+	resp, err := calc.CalculateDamageCore(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	verifyDist(t, "DamageDist", resp.DamageDist, expectedDamageDist)
+}
+
 func intPtr(i int) *int {
 	return &i
 }

--- a/internal/calculator/damage_dist.go
+++ b/internal/calculator/damage_dist.go
@@ -42,7 +42,8 @@ func _calculateDamageDistribution(damage DiceRoll, feelNoPain *int) map[int]floa
 	return applyFeelNoPain(baseDist, *feelNoPain)
 }
 
-// This replaces the string-parsing version with a direct mathematical approach.
+// generateDiceDistribution computes the exact PMF of a dice roll via direct
+// convolution (no string parsing involved).
 func generateDiceDistribution(d DiceRoll) map[int]float64 {
 	// Base case: If there are no dice to roll (e.g., flat damage "3"),
 	// start with 100% probability at 0, then add the modifier.
@@ -50,26 +51,8 @@ func generateDiceDistribution(d DiceRoll) map[int]float64 {
 		return map[int]float64{applyDamageFloor(d.Modifier): 1.0}
 	}
 
-	// 1. Initialize distribution with the first die (1 to Sides)
-	currentDist := make(map[int]float64)
-	prob := 1.0 / float64(d.Sides)
-	for i := 1; i <= d.Sides; i++ {
-		currentDist[i] = prob
-	}
+	currentDist := rollDiceDistribution(d.Count, d.Sides)
 
-	// 2. Convolve for additional dice (O(Count * Sides * Outcomes))
-	// Example: turning 1d6 distribution into 2d6, then 3d6...
-	for i := 1; i < d.Count; i++ {
-		newDist := make(map[int]float64)
-		for valA, probA := range currentDist {
-			for valDie := 1; valDie <= d.Sides; valDie++ {
-				newDist[valA+valDie] += probA * prob
-			}
-		}
-		currentDist = newDist
-	}
-
-	// 3. Apply Modifier and Damage Floor
 	// In 40k, damage/attacks generally cannot be modified below 1.
 	finalDist := make(map[int]float64)
 	for val, p := range currentDist {
@@ -96,7 +79,6 @@ func applyFeelNoPain(baseDist map[int]float64, fnpVal int) map[int]float64 {
 
 	pFail := 1.0 - pSave
 
-	// Iterate over every possible incoming damage amount
 	for incomingDmg, incomingProb := range baseDist {
 		// For a specific amount of damage 'n', the actual damage taken 'k'
 		// follows a Binomial Distribution B(n, pFail).
@@ -107,7 +89,6 @@ func applyFeelNoPain(baseDist map[int]float64, fnpVal int) map[int]float64 {
 			combinatorics := float64(nCr(incomingDmg, k))
 			probKFailed := combinatorics * math.Pow(pFail, float64(k)) * math.Pow(pSave, float64(incomingDmg-k))
 
-			// Add weighted probability to the final map
 			fnpDist[k] += incomingProb * probKFailed
 		}
 	}

--- a/internal/calculator/hit_dist.go
+++ b/internal/calculator/hit_dist.go
@@ -51,32 +51,22 @@ func CalculateSingleHitDistribution(
 			continue
 		}
 
-		// 2. Determine Outcome for this Face
 		outcome := resolveDieOutcome(face, bs, hitModifier, criticalThreshold, lethalHits, sustainedHits)
-
-		// 3. Add to Distribution
 		dist[outcome] += prob
 	}
 
 	return dist
 }
 
-// Helper: Determine what happens on a specific physical die roll
+// Determine what happens on a specific physical die roll.
 func resolveDieOutcome(face int, bs int, mod int, critThreshold int, lethal bool, sustained int) HitOutcome {
 	// Critical Hits are usually based on Unmodified rolls in 10th
 	isCrit := face >= critThreshold // e.g., 6 >= 6
 
-	// Calculate Modified Roll for standard hits
-	modRoll := face + mod
-	if modRoll > 6 {
-		modRoll = 6
-	}
-	if modRoll < 1 {
-		modRoll = 1
-	}
+	modRoll := clampToD6Range(face + mod)
 
-	// Check Hit (Nat 1 always fails, Nat 6 always succeeds usually, but Criticals override)
-	// In 10th: Unmodified 6 is Critical Hit (auto hit). Unmodified 1 is fail.
+	// A natural 1 always fails and a natural 6 is a Critical Hit (auto-success);
+	// Criticals override the modified-roll check entirely.
 	isHit := isCrit || (modRoll >= bs && face != 1)
 
 	if !isHit {
@@ -85,15 +75,13 @@ func resolveDieOutcome(face int, bs int, mod int, critThreshold int, lethal bool
 
 	outcome := HitOutcome{}
 
-	// Apply Lethal Hits
 	if isCrit && lethal {
 		outcome.LethalHits = 1
 	} else {
 		outcome.NormalHits = 1
 	}
 
-	// Apply Sustained Hits (Add X *additional* hits)
-	// Sustained hits are normally treated as Normal Hits (they don't trigger Lethals recursively)
+	// Sustained hits are treated as Normal Hits; they don't trigger Lethals recursively.
 	if isCrit && sustained > 0 {
 		outcome.NormalHits += sustained
 	}
@@ -101,12 +89,22 @@ func resolveDieOutcome(face int, bs int, mod int, critThreshold int, lethal bool
 	return outcome
 }
 
-// Helper: Handle Reroll Logic to get P(Face)
+// clampToD6Range clamps a modified roll into the valid [1, 6] die range.
+func clampToD6Range(v int) int {
+	if v > 6 {
+		return 6
+	}
+	if v < 1 {
+		return 1
+	}
+	return v
+}
+
+// Reroll logic: computes P(Face) for each die face under rerollType.
 func resolveRerolls(bs, mod int, reroll RerollType) map[int]float64 {
 	probs := make(map[int]float64)
 	base := 1.0 / 6.0
 
-	// Initial Rolls
 	for i := 1; i <= 6; i++ {
 		probs[i] = base
 	}
@@ -115,7 +113,6 @@ func resolveRerolls(bs, mod int, reroll RerollType) map[int]float64 {
 		return probs
 	}
 
-	// Calculate Reroll Pool
 	rerollPool := 0.0
 	shouldReroll := func(face int) bool {
 		if reroll == RerollOnes {
@@ -123,13 +120,7 @@ func resolveRerolls(bs, mod int, reroll RerollType) map[int]float64 {
 		}
 		if reroll == RerollFail {
 			// Fail check: Nat 1 or Modified < BS
-			modRoll := face + mod
-			if modRoll > 6 {
-				modRoll = 6
-			}
-			if modRoll < 1 {
-				modRoll = 1
-			}
+			modRoll := clampToD6Range(face + mod)
 			return face == 1 || modRoll < bs
 		}
 		return false

--- a/internal/calculator/model.go
+++ b/internal/calculator/model.go
@@ -58,16 +58,14 @@ type TargetProfile struct {
 }
 
 type SimulationSettings struct {
-	HitReroll   RerollType
-	WoundReroll RerollType
-	SaveReroll  RerollType
-	// Thresholds
+	HitReroll              RerollType
+	WoundReroll            RerollType
+	SaveReroll             RerollType
 	CriticalHitThreshold   int
 	CriticalWoundThreshold int
-	//modifiers
-	SaveModifier  int
-	HitModifier   int
-	WoundModifier int
+	SaveModifier           int
+	HitModifier            int
+	WoundModifier          int
 }
 
 // dice string struct - 2d6 + 1
@@ -77,7 +75,7 @@ type DiceRoll struct {
 	Modifier int // Flat bonus (e.g., +1)
 }
 
-// RerollType definitions
+// RerollType enumerates the supported dice-reroll rules.
 type RerollType int
 
 const (
@@ -85,12 +83,10 @@ const (
 	RerollNone RerollType = iota
 	RerollOnes
 	RerollFail
-	// Add more types as needed
 )
 
 // String implements the fmt.Stringer interface to provide a readable string value.
 func (r RerollType) String() string {
-	// Map the integer value back to a descriptive string.
 	if r < 0 || int(r) >= len(rerollTypeNames) {
 		return fmt.Sprintf("UnknownRerollType(%d)", r)
 	}
@@ -125,7 +121,6 @@ func (r *RerollType) UnmarshalJSON(b []byte) error {
 	return fmt.Errorf("unknown RerollType: %s", s)
 }
 
-// response
 type SimulationResult struct {
 	AverageHits      float64
 	AverageDestroyed float64

--- a/internal/calculator/save_prop.go
+++ b/internal/calculator/save_prop.go
@@ -59,45 +59,63 @@ func CalculateFailedSaveProbability(ap int, save int, invulnerable *int, saveMod
 
 	const oneSixth = 1.0 / 6.0
 
-	// 1. Calculate the Benefit of Cover specifically
 	bocModifier := _getBenefitOfCoverModifier(save, ap, hasCover)
+	armorSaveTarget := modifiedArmorSaveTarget(save, ap, saveModifier, bocModifier)
+	finalTarget := betterSaveTarget(armorSaveTarget, invulnerable)
 
-	// 2. Calculate the Modified Armor Save
-	// Total modifier is the general saveModifier + the BoC bonus
-	totalModifier := saveModifier + bocModifier
-	armorSaveTarget := save + ap - totalModifier
-
-	// 3. Determine the "Best" Save Target
-	finalTarget := armorSaveTarget
-	if invulnerable != nil {
-		invulnTarget := *invulnerable
-		if invulnTarget < finalTarget {
-			finalTarget = invulnTarget
-		}
+	finalTarget, autoFail := clampSaveTarget(finalTarget)
+	if autoFail {
+		return 1.0
 	}
 
-	// 4. Apply Caps (1 always fails, cannot pass if > 6)
-	if finalTarget < 2 {
-		finalTarget = 2
-	}
-
-	if finalTarget > 6 {
-		return 1.0 // 100% fail rate
-	}
-
-	// 5. Calculate Base Probabilities
-	passChance := (7.0 - float64(finalTarget)) / 6.0
+	passChance := chanceOfRollingAtLeast(float64(finalTarget))
 	failChance := 1.0 - passChance
 
-	// 6. Handle Rerolls
 	switch saveReroll {
 	case RerollOnes:
-		// If we roll a 1 (1/6), we retry and get another passChance
-		failChance -= oneSixth * passChance
+		// Only a natural 1 can be rerolled.
+		failChance = applyRerollReduction(failChance, passChance, oneSixth)
 	case RerollFail:
-		// If we fail (failChance), we retry and get another passChance
-		failChance -= failChance * passChance
+		// Every failed roll can be rerolled.
+		failChance = applyRerollReduction(failChance, passChance, failChance)
 	}
 
 	return math.Max(0.0, failChance)
+}
+
+// modifiedArmorSaveTarget applies the general save modifier and the Benefit
+// of Cover bonus to the defender's armor save.
+func modifiedArmorSaveTarget(save, ap, saveModifier, bocModifier int) int {
+	totalModifier := saveModifier + bocModifier
+	return save + ap - totalModifier
+}
+
+// betterSaveTarget returns the lower (easier) of the armor save target and
+// the invulnerable save, if one is present; a lower target is always at
+// least as good, since invulnerable saves ignore AP and modifiers.
+func betterSaveTarget(armorTarget int, invulnerable *int) int {
+	if invulnerable != nil && *invulnerable < armorTarget {
+		return *invulnerable
+	}
+	return armorTarget
+}
+
+// clampSaveTarget applies the core rules floor and ceiling: a natural 1
+// always fails, so no save can need better than 2+; nothing beyond 6+ is
+// rollable, so any higher requirement auto-fails the save entirely.
+func clampSaveTarget(target int) (clamped int, autoFail bool) {
+	if target < 2 {
+		target = 2
+	}
+	if target > 6 {
+		return 0, true
+	}
+	return target, false
+}
+
+// applyRerollReduction subtracts the chance that a reroll turns a fail into
+// a pass: a second attempt happens with probability retryChance, so
+// retryChance*passChance of the original failures are saved.
+func applyRerollReduction(failChance, passChance, retryChance float64) float64 {
+	return failChance - retryChance*passChance
 }

--- a/internal/calculator/save_prop_test.go
+++ b/internal/calculator/save_prop_test.go
@@ -108,6 +108,40 @@ func TestCalculateFailedSaveProbability(t *testing.T) {
 			// Total fail: (1/6) + (1/6 * 2/6) = 6/36 + 2/36 = 8/36 = 2/9
 			expectedFailChance: 2.0 / 9.0,
 		},
+		{
+			// Invulnerable (4+) is better than the armor save (6+), so it wins.
+			name:               "Invulnerable Save Beats Worse Armor Save",
+			ap:                 0,
+			save:               6,
+			invulnerable:       intPtr(4),
+			saveModifier:       0,
+			hasCover:           false,
+			saveReroll:         RerollNone,
+			expectedFailChance: 3.0 / 6.0,
+		},
+		{
+			// Save 6+ vs AP 2 needs 8+, beyond the rollable 6+: auto-fail.
+			name:               "Target Beyond 6+ Auto-Fails",
+			ap:                 2,
+			save:               6,
+			invulnerable:       nil,
+			saveModifier:       0,
+			hasCover:           false,
+			saveReroll:         RerollNone,
+			expectedFailChance: 1.0,
+		},
+		{
+			// Reroll Fail Test: base fail 2/6, both the original roll and its
+			// reroll must fail, so total fail = (2/6)^2 = 1/9.
+			name:               "Save 3+ with Reroll Fails",
+			ap:                 0,
+			save:               3,
+			invulnerable:       nil,
+			saveModifier:       0,
+			hasCover:           false,
+			saveReroll:         RerollFail,
+			expectedFailChance: 1.0 / 9.0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/calculator/wound_prob.go
+++ b/internal/calculator/wound_prob.go
@@ -36,67 +36,93 @@ import (
 //
 // Returns:
 // (float64, float64): Probability of a normal wound and a devastating wound.
-
 func CalculateWoundProbability(s int, t int, rerollType RerollType, woundModifier int, devastatingWounds bool,
 	CriticalWoundThreshold int) (float64, float64) {
-	// Constants
 	const oneSixth = 1.0 / 6.0
 
-	// 1. Determine the required Wound Roll (Target Wound Roll)
-	var targetRoll int
-	if s*2 <= t {
-		targetRoll = 6
-	} else if s < t {
-		targetRoll = 5
-	} else if s >= t*2 {
-		targetRoll = 2
-	} else if s > t {
-		targetRoll = 3
-	} else {
-		targetRoll = 4
-	}
+	finalTargetRoll := clampWoundTarget(woundRollTarget(s, t), woundModifier)
+	woundChance := chanceOfRollingAtLeast(finalTargetRoll)
 
-	// 2. Apply the modifier and clamp between 2+ and 6+
-	finalTargetRoll := float64(targetRoll) - float64(woundModifier)
-	finalTargetRoll = math.Max(2.0, math.Min(6.0, finalTargetRoll))
+	critChance := chanceOfRollingAtLeast(float64(sanitizeCriticalThreshold(CriticalWoundThreshold)))
 
-	// 1. Calculate Base Success Chance (Normal math)
-	woundChance := (7.0 - finalTargetRoll) / 6.0
-
-	// 2. Calculate Critical Success Chance
-	if CriticalWoundThreshold < 2 || CriticalWoundThreshold > 6 {
-		CriticalWoundThreshold = 6
-	}
-	critChance := (7.0 - float64(CriticalWoundThreshold)) / 6.0
-
-	// 3. APPLY RULE: Critical Wounds are always successful
-	// If critChance is higher than woundChance (e.g., Anti-2+ vs T12),
-	// the woundChance must be elevated to the critChance.
+	// Critical Wounds are always successful: if critChance is higher than
+	// woundChance (e.g., Anti-2+ vs T12), woundChance is elevated to match.
 	if critChance > woundChance {
 		woundChance = critChance
 	}
 
 	missChance := 1.0 - woundChance
 
-	// 4. Process Rerolls
 	switch rerollType {
 	case RerollOnes:
-		// Rerolling a 1 (1/6) gives another chance to hit wound or crit
-		woundChance += oneSixth * woundChance
-		critChance += oneSixth * critChance
+		// Only a natural 1 can be rerolled.
+		woundChance = applyRerollBonus(woundChance, oneSixth)
+		critChance = applyRerollBonus(critChance, oneSixth)
 	case RerollFail:
-		// Rerolling all fails (missChance) gives another chance to hit wound or crit
-		woundChance += missChance * woundChance
-		critChance += missChance * critChance
+		// Every failed roll can be rerolled.
+		woundChance = applyRerollBonus(woundChance, missChance)
+		critChance = applyRerollBonus(critChance, missChance)
 	}
 
-	// 5. Process [DEVASTATING WOUNDS]
-	devastatingWoundChance := 0.0
-	if devastatingWounds {
-		devastatingWoundChance = critChance
-		woundChance -= devastatingWoundChance
-		woundChance = math.Max(0.0, woundChance)
-	}
+	woundChance, devastatingWoundChance := splitDevastatingWounds(woundChance, critChance, devastatingWounds)
 
 	return woundChance, devastatingWoundChance
+}
+
+// woundRollTarget returns the unmodified D6 roll needed to wound. Per the
+// core rules Strength-vs-Toughness table: S >= 2T wounds on 2+, S > T on
+// 3+, S == T on 4+, S < T on 5+, S <= T/2 on 6+.
+func woundRollTarget(s, t int) int {
+	switch {
+	case s*2 <= t:
+		return 6
+	case s < t:
+		return 5
+	case s >= t*2:
+		return 2
+	case s > t:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// clampWoundTarget applies the wound-roll modifier and clamps to the core
+// rules' legal target range: no roll can need better than 2+ or worse than
+// 6+ to succeed.
+func clampWoundTarget(targetRoll, modifier int) float64 {
+	v := float64(targetRoll) - float64(modifier)
+	return math.Max(2.0, math.Min(6.0, v))
+}
+
+// chanceOfRollingAtLeast returns P(roll >= target) on a fair D6.
+func chanceOfRollingAtLeast(target float64) float64 {
+	return (7.0 - target) / 6.0
+}
+
+// sanitizeCriticalThreshold resets an out-of-range threshold to the core
+// rules default: critical only on a natural 6.
+func sanitizeCriticalThreshold(v int) int {
+	if v < 2 || v > 6 {
+		return 6
+	}
+	return v
+}
+
+// applyRerollBonus adds the probability of succeeding on a reroll: a second
+// attempt happens with probability retryChance, and succeeds at the same
+// rate as the original roll, so the bonus is retryChance*chance.
+func applyRerollBonus(chance, retryChance float64) float64 {
+	return chance + retryChance*chance
+}
+
+// splitDevastatingWounds separates the devastating-wound share out of the
+// total wound chance. Per the core rules, [DEVASTATING WOUNDS] wounds
+// bypass the save roll entirely, so they must be resolved separately from
+// ordinary wounds rather than folded into woundChance.
+func splitDevastatingWounds(woundChance, critChance float64, devastatingWounds bool) (normal, devastating float64) {
+	if !devastatingWounds {
+		return woundChance, 0.0
+	}
+	return math.Max(0.0, woundChance-critChance), critChance
 }

--- a/internal/middleware/cors_middleware.go
+++ b/internal/middleware/cors_middleware.go
@@ -26,45 +26,48 @@ import (
 )
 
 func CORSMiddleware(allowedOrigins map[string]bool) func(http.Handler) http.Handler {
-	// Normalize map for O(1) lookup
-	normalizedAllowed := make(map[string]bool)
-	for k, v := range allowedOrigins {
-		normalized := strings.TrimSuffix(strings.ToLower(k), "/")
-		normalizedAllowed[normalized] = v
-	}
+	normalizedAllowed := normalizeOriginSet(allowedOrigins)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			rawOrigin := r.Header.Get("Origin")
 
-			// 1. Missing Origin: Pass through (Server-to-Server / Same-Origin)
+			// Server-to-Server / Same-Origin requests carry no Origin header.
 			if rawOrigin == "" {
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			// 2. Normalize and Check
 			origin := strings.TrimSuffix(strings.ToLower(rawOrigin), "/")
 
 			if normalizedAllowed[origin] {
-				// Match found: Decorate response
-				w.Header().Set("Access-Control-Allow-Origin", rawOrigin)
-				w.Header().Set("Vary", "Origin")
-				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Request-ID")
-				w.Header().Set("Access-Control-Allow-Credentials", "true")
-				w.Header().Set("Access-Control-Max-Age", "86400")
+				setCORSHeaders(w, rawOrigin)
 
-				// Handle Preflight for allowed origins only
 				if r.Method == http.MethodOptions {
 					w.WriteHeader(http.StatusNoContent)
 					return
 				}
 			}
 
-			// 3. Unauthorized / Non-Matching: Pass through
 			// The browser will block the response due to missing CORS headers.
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func normalizeOriginSet(allowedOrigins map[string]bool) map[string]bool {
+	normalized := make(map[string]bool)
+	for k, v := range allowedOrigins {
+		normalized[strings.TrimSuffix(strings.ToLower(k), "/")] = v
+	}
+	return normalized
+}
+
+func setCORSHeaders(w http.ResponseWriter, origin string) {
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Vary", "Origin")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Request-ID")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
+	w.Header().Set("Access-Control-Max-Age", "86400")
 }

--- a/pkg/handler/error_helper.go
+++ b/pkg/handler/error_helper.go
@@ -31,7 +31,9 @@ type APIError struct {
 	RequestUUID string `json:"request_uuid"`
 }
 
-// SendError sends a standardized JSON error response.
+// SendError writes an APIError as the JSON response body, setting the
+// Content-Type header and status code. reqID may be empty if none was
+// resolved for the request.
 func SendError(w http.ResponseWriter, reqID string, message string, code int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)

--- a/pkg/models/calcDamage.go
+++ b/pkg/models/calcDamage.go
@@ -51,9 +51,8 @@ type AttackerDTO struct {
 	LethalHits        bool `json:"lethal_hits,omitempty"`
 	DevastatingWounds bool `json:"devastating_wounds,omitempty"`
 	Torrent           bool `json:"torrent,omitempty"`
-	// Modifiers (e.g., -1 to hit is -1)
-	HitModifier   int `json:"hit_modifier,omitempty"`
-	WoundModifier int `json:"wound_modifier,omitempty"`
+	HitModifier       int  `json:"hit_modifier,omitempty"`
+	WoundModifier     int  `json:"wound_modifier,omitempty"`
 }
 
 // TargetDTO includes defensive layers and resilience rules.
@@ -78,38 +77,20 @@ type RulesDTO struct {
 	CriticalWoundThreshold int `json:"critical_wound_threshold,omitempty"`
 }
 
-// --- Validator ---
 func (req *DamageRequestDTO) Validate() error {
-	// 1. Basic Existence
-	if req.Attacker.NumModels <= 0 {
-		return errors.New("attacker.num_models must be positive")
+	if err := validateExistence(req); err != nil {
+		return err
 	}
-	if req.Attacker.S <= 0 || req.Target.T <= 0 {
-		return errors.New("strength and toughness must be positive")
-	}
-	if req.Target.WoundsPerModel <= 0 {
-		return errors.New("target.wounds_per_model must be positive")
+	if err := validateGameLegalRules(req); err != nil {
+		return err
 	}
 
-	// 2. Impossible-by-Rules (Game Logic)
-	// BS 1+ is impossible (rolls of 1 always fail). BS 6+ is the worst possible.
-	if !req.Attacker.Torrent && (req.Attacker.BS < 2 || req.Attacker.BS > 6) {
-		return errors.New("bs must be between 2 and 6 (unless Torrent)")
-	}
-
-	// Save 1+ is impossible.
-	if req.Target.Save < 2 {
-		return errors.New("save must be 2+ or higher")
-	}
-
-	// Invulnerable checks
 	if req.Target.Invulnerable != nil {
 		if *req.Target.Invulnerable < 2 || *req.Target.Invulnerable > 6 {
 			return errors.New("invulnerable save must be between 2+ and 6+")
 		}
 	}
 
-	// Feel No Pain checks
 	if req.Target.FeelNoPain != nil {
 		if *req.Target.FeelNoPain < 2 || *req.Target.FeelNoPain > 6 {
 			return errors.New("fnp must be between 2+ and 6+")
@@ -122,7 +103,6 @@ func (req *DamageRequestDTO) Validate() error {
 		}
 	}
 
-	// Critical Thresholds
 	if req.Rules.CriticalHitThreshold != 0 && (req.Rules.CriticalHitThreshold < 2 || req.Rules.CriticalHitThreshold > 6) {
 		return errors.New("critical hit threshold must be between 2 and 6")
 	}
@@ -130,7 +110,6 @@ func (req *DamageRequestDTO) Validate() error {
 		return errors.New("critical wound threshold must be between 2 and 6")
 	}
 
-	// Blast Requirements
 	if req.Attacker.Blast {
 		if req.Target.ModelCount == nil {
 			return errors.New("target.model_count is required for Blast weapons")
@@ -143,24 +122,53 @@ func (req *DamageRequestDTO) Validate() error {
 	return nil
 }
 
+func validateExistence(req *DamageRequestDTO) error {
+	if req.Attacker.NumModels <= 0 {
+		return errors.New("attacker.num_models must be positive")
+	}
+	if req.Attacker.S <= 0 || req.Target.T <= 0 {
+		return errors.New("strength and toughness must be positive")
+	}
+	if req.Target.WoundsPerModel <= 0 {
+		return errors.New("target.wounds_per_model must be positive")
+	}
+	return nil
+}
+
+// validateGameLegalRules rejects values that are impossible under core dice
+// mechanics, regardless of what the caller sends.
+func validateGameLegalRules(req *DamageRequestDTO) error {
+	// BS 1+ is impossible (rolls of 1 always fail). BS 6+ is the worst possible.
+	if !req.Attacker.Torrent && (req.Attacker.BS < 2 || req.Attacker.BS > 6) {
+		return errors.New("bs must be between 2 and 6 (unless Torrent)")
+	}
+
+	// Save 1+ is impossible.
+	if req.Target.Save < 2 {
+		return errors.New("save must be 2+ or higher")
+	}
+
+	return nil
+}
+
 var diceRegex = regexp.MustCompile(`(?i)^(\d*)d(\d+)\s*([+-]\s*\d+)?$`)
 
 // ParseDiceString converts "2d6+1" or "4" into a clean DiceRoll struct
 func ParseDiceString(input string) (calculator.DiceRoll, error) {
 	input = strings.TrimSpace(input)
 
-	// 1. Handle Fixed Number (e.g. "4")
+	// Fixed number, e.g. "4".
 	if val, err := strconv.Atoi(input); err == nil {
 		return calculator.DiceRoll{Count: 0, Sides: 0, Modifier: val}, nil
 	}
 
-	// 2. Handle Dice String (e.g. "2d6+1")
+	// Dice string, e.g. "2d6+1".
 	matches := diceRegex.FindStringSubmatch(input)
 	if matches == nil {
 		return calculator.DiceRoll{}, fmt.Errorf("invalid format '%s'", input)
 	}
 
-	// Parse Count (default to 1 if empty, e.g. "d6")
+	// Empty count defaults to 1, e.g. "d6" means 1d6.
 	count := 1
 	if matches[1] != "" {
 		var err error
@@ -170,18 +178,15 @@ func ParseDiceString(input string) (calculator.DiceRoll, error) {
 		}
 	}
 
-	// Parse Sides
 	sides, err := strconv.Atoi(matches[2])
 	if err != nil || sides <= 0 {
 		return calculator.DiceRoll{}, fmt.Errorf("invalid die type")
 	}
 
-	// Parse Modifier
 	mod := 0
 	if matches[3] != "" {
-		// Remove whitespace inside modifier string (e.g. "+ 1" -> "+1")
-		cleanMod := strings.ReplaceAll(matches[3], " ", "")
-		mod, err = strconv.Atoi(cleanMod)
+		modifierWithoutSpaces := strings.ReplaceAll(matches[3], " ", "")
+		mod, err = strconv.Atoi(modifierWithoutSpaces)
 		if err != nil {
 			return calculator.DiceRoll{}, fmt.Errorf("invalid modifier: %w", err)
 		}
@@ -196,24 +201,14 @@ func ParseDiceString(input string) (calculator.DiceRoll, error) {
 
 // --- Converter (The Mapper) ---
 func (req *DamageRequestDTO) ToDomain() (calculator.CombatSimulationRequest, error) {
-	// Logic for defaulting thresholds to 6 if not provided
-	critHit := req.Rules.CriticalHitThreshold
-	if critHit == 0 {
-		critHit = 6
-	}
+	critHit := defaultThreshold(req.Rules.CriticalHitThreshold, 6)
+	critWound := defaultThreshold(req.Rules.CriticalWoundThreshold, 6)
 
-	critWound := req.Rules.CriticalWoundThreshold
-	if critWound == 0 {
-		critWound = 6
-	}
-
-	// 1. Parse Attacks
 	attacks, err := ParseDiceString(req.Attacker.AttacksString)
 	if err != nil {
 		return calculator.CombatSimulationRequest{}, fmt.Errorf("attacker attacks: %w", err)
 	}
 
-	// 2. Parse Damage
 	damage, err := ParseDiceString(req.Attacker.D)
 	if err != nil {
 		return calculator.CombatSimulationRequest{}, fmt.Errorf("attacker damage: %w", err)
@@ -258,10 +253,14 @@ func (req *DamageRequestDTO) ToDomain() (calculator.CombatSimulationRequest, err
 	return model, nil
 }
 
-//for response
+func defaultThreshold(v, fallback int) int {
+	if v == 0 {
+		return fallback
+	}
+	return v
+}
 
 type DamageResponseDTO struct {
-	// Grouped or flattened as you prefer, but separate from the core
 	Summary       SummaryDTO       `json:"summary"`
 	Distributions DistributionsDTO `json:"distributions"`
 


### PR DESCRIPTION
Removes "what-comments" — comments that only restate what the adjacent code
already says — across the codebase. Per the audit rubric, CRUD/infrastructure
packages end at zero what-comments; the math-heavy `internal/calculator`
package retains and refines comments that carry real domain knowledge
(rule derivations, distribution/Markov-chain semantics) rather than deleting
them for the sake of a clean count.