### PR TITLE
docs(commit-policy): add DORMANT FEATURE and COMMENTS required fields

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -20,6 +20,18 @@ TESTS:
   - [ ] error cases
   - [ ] invariants / properties
 
-POLICY EXCEPTION:
-- Required: no
+DORMANT FEATURE: yes | no
+- If yes:
+  - What feature/rule does it implement?
+  - Coverage (choose one):
+    - [ ] full test suite (dormant behavior itself verified correct)
+    - [ ] regression guard test (fails if activated without verification)
+
+COMMENTS: yes | no
+- If yes, reason (choose one):
+  - [ ] complex math the code's structure can't convey on its own (briefly: what)
+  - [ ] external rule / domain constraint the code's structure can't convey (briefly: what/source)
+  - [ ] was compensating for unclear code — reworked and removed (briefly: method used)
+
+POLICY EXCEPTION: yes | no
 - If yes, explain which rule is broken and why.

--- a/commit-policy.md
+++ b/commit-policy.md
@@ -42,11 +42,55 @@ The commit introducing transitional code MUST explain:
 - why it exists,
 - how it will be removed.
 
+## Dormant Feature Rule
+
+Dormant code is code that implements a real, specified feature or rule but
+is intentionally inactive — behind a flag, an unreachable branch, or a
+default-off condition.
+
+Dormant code MUST be covered by one of:
+- a full test suite verifying the dormant behavior itself is correct, or
+- a regression guard test that fails if the feature is activated without
+  that verification work having been done.
+
+The commit that introduces or modifies dormant code MUST declare
+`DORMANT FEATURE: yes` and explain:
+- what feature or rule the code implements,
+- which of the two coverage options above was used.
+
+## Comment Rule
+
+All comments MUST be written in English.
+
+Comments that explain *what* code does ("what-comments") are prohibited by
+default. A what-comment MAY be kept only if:
+- it explains complex math that the code's structure cannot convey on its
+  own, or
+- it explains an external rule or domain constraint (e.g. wargame rules,
+  physics, regulation) that the code's structure cannot convey on its own.
+
+A what-comment that exists only because the surrounding code is unclear
+(poor naming, unstructured logic) is not a valid reason to keep it. The
+code MUST instead be reworked until the comment is unnecessary — renaming,
+extracting a function, naming a constant, etc. — and the comment removed.
+
+Comments that explain *why* code exists or behaves a certain way
+("why-comments": rationale, invariants, warnings, workarounds) are not
+restricted by this rule.
+
+The commit MUST declare `COMMENTS: yes` if it adds, retains, or eliminates
+any what-comment, and explain:
+- which of the two valid reasons above applies, if one was kept, or
+- if the comment was compensating for unclear code, what method was used
+  to make it redundant, confirming it was removed.
+
 ## Commit Message Format
 
 All commits MUST declare:
 - ATOMICITY
 - TESTS
+- DORMANT FEATURE
+- COMMENTS
 
 If any rule is intentionally broken, the commit MUST declare:
 - `POLICY EXCEPTION: yes`


### PR DESCRIPTION
WHY:
- Prior incident review (FNP duplicate calc, devastating-wounds spillover flag, what-comment audit) surfaced two unenforced gaps: dormant code with no activation safeguard, and what-comments with no declared justification.
- Formalizes both as required, enforceable commit-message fields rather than relying on reviewer discretion.