### PR TITLE
ci(commit-policy): enforce dormant feature and comments fields

### DIFF
--- a/scripts/validate-commit-msg.sh
+++ b/scripts/validate-commit-msg.sh
@@ -33,19 +33,31 @@ if ! echo "$COMMIT_MSG" | grep -qE "$TYPE_REGEX(\(.*\))?: .*"; then
 fi
 
 # 2. Mandatory Fields (Literal match)
-for field in "ATOMICITY:" "TESTS:"; do
+for field in "ATOMICITY:" "TESTS:" "DORMANT FEATURE:" "COMMENTS:"; do
   if ! echo "$COMMIT_MSG" | grep -q "$field"; then
     echo "ERROR: Missing mandatory field: $field"
     exit 1
   fi
 done
 
-# 3. Justification Logic (Check for non-whitespace content on next line)
-if echo "$COMMIT_MSG" | grep -q "POLICY EXCEPTION: yes"; then
-  # Extract line after the match, trim it, check if empty
-  JUSTIFICATION=$(grep -A 1 "POLICY EXCEPTION: yes" "$COMMIT_MSG_FILE" | tail -n 1 | xargs)
-  if [[ -z "$JUSTIFICATION" ]]; then
-    echo "ERROR: POLICY EXCEPTION: yes requires a justification on the following line."
-    exit 1
+# 3. Justification Logic (Check for non-whitespace content on next line).
+# Applies to every field where "yes" marks a notable/exception case that
+# commit-policy.md requires an explanation for.
+require_justification_if_yes() {
+  local field_label="$1"
+  if echo "$COMMIT_MSG" | grep -q "${field_label}: yes"; then
+    local justification
+    justification=$(awk -v pat="${field_label}: yes" '
+      found { print; exit }
+      $0 ~ pat { found=1 }
+    ' "$COMMIT_MSG_FILE" | xargs)
+    if [[ -z "$justification" ]]; then
+      echo "ERROR: ${field_label}: yes requires a justification on the following line."
+      exit 1
+    fi
   fi
-fi
+}
+
+for field_label in "POLICY EXCEPTION" "DORMANT FEATURE" "COMMENTS"; do
+  require_justification_if_yes "$field_label"
+done

--- a/scripts/validate-commit-msg_test.sh
+++ b/scripts/validate-commit-msg_test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Olbutov Aleksandr
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATOR="$SCRIPT_DIR/validate-commit-msg.sh"
+TMP_MSG="$(mktemp)"
+trap 'rm -f "$TMP_MSG"' EXIT
+
+cat > "$TMP_MSG" <<'EOF'
+ci(commit-policy): sample commit for validator happy-path test
+
+ATOMICITY: yes
+TESTS: yes
+DORMANT FEATURE: yes
+Guards a feature flag; regression test added.
+COMMENTS: no
+POLICY EXCEPTION: no
+EOF
+
+if ! bash "$VALIDATOR" "$TMP_MSG"; then
+  echo "FAIL: validator rejected a well-formed commit message"
+  exit 1
+fi
+
+echo "PASS: validator accepts a well-formed commit message"


### PR DESCRIPTION
WHY:
- PR#15 (0cfb2d4) added dormant feature and comments as required commit-message fields in commit-policy.md and .gitmessage, but validate-commit-msg.sh only checked for atomicity: yes and test: yes, so a commit missing the new fields would still pass the hook.
- Adds both fields to the mandatory-field check and generalizes the justification-required-when-affirmative check (previously hardcoded to policy exception only) so it also covers the dormant and comments fields.

ATOMICITY:
- Atomic: yes

TRANSITIONAL CODE:
- Transitional code introduced: no

TESTS:
- Tests added in this commit:
  - [x] happy-path
  - [ ] error cases
  - [ ] invariants / properties scripts/validate-commit-msg_test.sh feeds the validator a well-formed commit message, including an affirmative dormant-feature declaration with justification, and asserts it exits 0.

DORMANT FEATURE: no

COMMENTS: no

POLICY EXCEPTION: no